### PR TITLE
fix(core): Update the getQueryFromRIO to use the correct order of typ…

### DIFF
--- a/packages/core/src/normalizers/getQueryFromRIO.js
+++ b/packages/core/src/normalizers/getQueryFromRIO.js
@@ -19,7 +19,7 @@ export const getQueryFromRIO = relationship => {
   }
 
   const { id: uuid, type: typeString } = relationship;
-  const [bundle, type] = typeString.split("--");
+  const [type, bundle] = typeString.split("--");
 
   return {
     bundle,


### PR DESCRIPTION
…e/bundle entity identifiers in

BREAKING CHANGE: Entity identifier is normalised in a different way, type/bundle is the correct
order