### PR TITLE
fix(core): Fixed wrong type parsing in getQueryFromRIO

### DIFF
--- a/packages/core/src/normalizers/getQueryFromRIO.js
+++ b/packages/core/src/normalizers/getQueryFromRIO.js
@@ -19,7 +19,7 @@ export const getQueryFromRIO = relationship => {
   }
 
   const { id: uuid, type: typeString } = relationship;
-  const [bundle, type] = typeString.split("--");
+  const [type, bundle] = typeString.split("--");
 
   return {
     bundle,


### PR DESCRIPTION
BREAKING CHANGE: The order is now correct in which the type is parsed. Solutions relying on the
previous (wrong) behaviour might break.